### PR TITLE
Fixes to cpp-optparse

### DIFF
--- a/OptionParser.cpp
+++ b/OptionParser.cpp
@@ -305,6 +305,18 @@ Values& OptionParser::parse_args(const vector<string>& v) {
         _values[it->dest()] = it->get_default();
   }
 
+  for (list<OptionGroup const*>::iterator group_it = _groups.begin(); group_it != _groups.end(); ++group_it) {
+      for (strMap::const_iterator it = (*group_it)->_defaults.begin(); it != (*group_it)->_defaults.end(); ++it) {
+          if (not _values.is_set(it->first))
+              _values[it->first] = it->second;
+      }
+      
+      for (list<Option>::const_iterator it = (*group_it)->_opts.begin(); it != (*group_it)->_opts.end(); ++it) {
+          if (it->get_default() != "" and not _values.is_set(it->dest()))
+              _values[it->dest()] = it->get_default();
+      }
+  }
+
   return _values;
 }
 

--- a/OptionParser.h
+++ b/OptionParser.h
@@ -141,6 +141,8 @@ class OptionParser {
     OptionParser& set_defaults(const std::string& dest, const std::string& val) {
       _defaults[dest] = val; return *this;
     }
+    template<typename T>
+    OptionParser& set_defaults(const std::string& dest, T t) { std::ostringstream ss; ss << t; _defaults[dest] = ss.str(); return *this; }
     OptionParser& enable_interspersed_args() { _interspersed_args = true; return *this; }
     OptionParser& disable_interspersed_args() { _interspersed_args = false; return *this; }
     OptionParser& add_option_group(const OptionGroup& group);


### PR DESCRIPTION
Default values for options can be set either with a string or another type because Option::set_default() has a templated version. OptionParser::set_defaults() only had a string version, so I added a templated one as well so we can do:
```c++
OptionParser parser = OptionParser();
parser.add_option("--option1").action("store").type("int").set_default("1");
parser.add_option("--option2").action("store").type("int").set_default(1);
parser.set_defaults("options1", "640");
parser.set_defaults("option2", 640); // now works
```

Default values for options inside an OptionGroup were not previously working:

```c++
OptionParser parser = OptionParser();
OptionGroup group = OptionGroup(parser, "Size Options", "Image Size Options.");
group.add_option("-w", "--width").action("store").type("int").set_default(640).help("default: %default");
group.add_option("-h", "--height").action("store").type("int").help("default: %default");
group.set_defaults("height", 480);
parser.add_option_group(group);

Values& parse_options = parser.parse_args(argc, argv);
std::cout << "width: " << int(parse_options.get("width")) << std::endl;
std::cout << "height: " << int(parse_options.get("height")) << std::endl;
```
would print:
```
width: 0
height: 0
```
When looking for default values, we now browse the OptionGroup list and look for default values in the options and at the OptionGroup level.
It now correctly prints:
```
width: 640
height: 480
```
